### PR TITLE
NSI-2656 oxygen bug

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -521,6 +521,7 @@ class TestSalinityFromTCP:
 
 class TestConvertOxygen:
     def test_convert_sbe63_oxygen(self):
+        # without thermistor temperature, this test won't catch the bug fixed in nsi-2656
         raw_oxygen = [31.06, 31.66, 32.59, 33.92, 34.82, 35.44]
         pressure = [0, 0, 0, 0, 0, 0]
         temperature = [30, 26, 20, 12, 6, 2]
@@ -530,6 +531,7 @@ class TestConvertOxygen:
         for index in range(len(expected)):
             result = dc.convert_sbe63_oxygen_val(
                 raw_oxygen[index],
+                temperature[index],
                 temperature[index],
                 pressure[index],
                 salinity[index],
@@ -542,6 +544,8 @@ class TestConvertOxygen:
                 cal.c1,
                 cal.c2,
                 cal.e,
+                1,
+                0,
             )
             assert np.allclose([expected[index]], [result], rtol=0, atol=1e-2)
 


### PR DESCRIPTION
# Description

Use thermistor temperature, slope, and offset to convert O2

Closes: NSI-2656

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Select the type of tests you added for these changes

- [ ] Unit
- [ ] Integration
- [ ] Component
- [ ] E2E
- [ ] User

## Did you test these changes on all platforms (if applicable to the JIRA item?)

- [x] Windows
- [ ] MacOS

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have cleared any run data/output from the ipynb file(s)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code is up to date with the branch I'm requesting to merge into
