### PR TITLE
TKIT-65 align CTD tests

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -37,6 +37,127 @@ class TestLowPassFilter:
         assert np.allclose(expected, filtered, rtol=0, atol=1e-4)
 
 
+class TestAlignCtdFathomCases:
+    # Test align CTD with same test data as Fathom
+    def test_align_ctd_basic_forward(self, request):
+        badFlagValue = -9.99e-29
+
+        align_cases = [
+            # Basic forward align cases
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),  # original
+                15,  # offset
+                15,  # sample interval
+                np.array([15, 30, 45, 60, 75, 90, 105, badFlagValue]),  # expected
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                10,
+                15,
+                np.array([10, 25, 40, 55, 70, 85, 100, badFlagValue]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                5,
+                15,
+                np.array([5, 20, 35, 50, 65, 80, 95, badFlagValue]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                0,
+                15,
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                11.575,
+                15,
+                np.array([11.575, 26.575, 41.575, 56.575, 71.575, 86.575, 101.575, badFlagValue]),
+            ],
+            # Advanced forward align cases
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                30,
+                15,
+                np.array([30, 45, 60, 75, 90, 105, badFlagValue, badFlagValue]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                20,
+                15,
+                np.array([20, 35, 50, 65, 80, 95, badFlagValue, badFlagValue]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                106,
+                15,
+                np.array([badFlagValue] * 8),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                60,
+                15,
+                np.array(
+                    [60, 75, 90, 105, badFlagValue, badFlagValue, badFlagValue, badFlagValue]
+                ),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                130,
+                15,
+                np.array([badFlagValue] * 8),
+            ],
+            # Basic backwards align cases
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                -15,
+                15,
+                np.array([badFlagValue, 0, 15, 30, 45, 60, 75, 90]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                -10,
+                15,
+                np.array([badFlagValue, 5, 20, 35, 50, 65, 80, 95]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                -5,
+                15,
+                np.array([badFlagValue, 10, 25, 40, 55, 70, 85, 100]),
+            ],
+            # Advanced backwards align cases
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                -30,
+                15,
+                np.array([badFlagValue, badFlagValue, 0, 15, 30, 45, 60, 75]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                -20,
+                15,
+                np.array([badFlagValue, badFlagValue, 10, 25, 40, 55, 70, 85]),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                -106,
+                15,
+                np.array([badFlagValue] * 8),
+            ],
+            [
+                np.array([0, 15, 30, 45, 60, 75, 90, 105]),
+                -130,
+                15,
+                np.array([badFlagValue] * 8),
+            ],
+        ]
+
+        for case in align_cases:
+            result = p.align_ctd(case[0], case[1], case[2])
+            assert np.array_equal(case[3], result)
+
+
 class TestAlignCtd:
     expected_data_path = test_data / "SBE37SM-align.cnv"
     expected_data = idata.cnv_to_instrument_data(expected_data_path)


### PR DESCRIPTION
# Description

Adds align CTD tests from Fathom to ensure toolkit matches Fathom.

SBE Data Processing handles the tail of the dataset differently. In SBE Data Processing if a parameter is jogged backwards, the missing values at the end are filled with extrapolated values. We've decided to not replicate that behavior in the toolkit and Fathom, instead the values are flagged and it is up to the user to decide how/if they want to extrapolate the data. 

Closes: TKIT-65 (if this is to address a JIRA issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the [Coding Style](../CONTRIBUTING.md#coding-style) and [Documenting](../CONTRIBUTING.md#documenting) sections of the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the docstrings in my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The processes listed in the [Formatting and Style Tools](../CONTRIBUTING.md#formatting-and-style-tools) section of the [Contributing Guidelines](../CONTRIBUTING.md) have been run and are free of issues.
- [x] New and existing unit tests pass locally with my changes
- [x] I have cleared any run data/output from the ipynb file(s)
- [x] My code is up to date with the branch I'm requesting to merge into
